### PR TITLE
Add support for individual multicast address RX without promiscuous mode

### DIFF
--- a/packet.go
+++ b/packet.go
@@ -132,6 +132,12 @@ func (c *Conn) SetPromiscuous(enable bool) error {
 	return c.setPromiscuous(enable)
 }
 
+// SetPromiscuous enables or disables promiscuous mode on the Conn, allowing it
+// to receive traffic that is not addressed to the Conn's network interface.
+func (c *Conn) SetMembership(enable bool, Type uint16, addr net.HardwareAddr) error {
+	return c.setMembership(enable, Type, addr)
+}
+
 // Stats contains statistics about a Conn reported by the Linux kernel.
 type Stats struct {
 	// The total number of packets received.

--- a/packet_linux.go
+++ b/packet_linux.go
@@ -51,9 +51,20 @@ func (c *Conn) writeTo(b []byte, addr net.Addr) (int, error) {
 
 // setPromiscuous wraps setsockopt(2) for the unix.PACKET_MR_PROMISC option.
 func (c *Conn) setPromiscuous(enable bool) error {
+	return c.setMembership(enable, unix.PACKET_MR_PROMISC, nil)
+}
+
+const ETH_ALEN uint16 = 6
+
+// setMembership wraps setsockopt(2) for PACKET_MR_*
+func (c *Conn) setMembership(enable bool, Type uint16, addr net.HardwareAddr) error {
 	mreq := unix.PacketMreq{
 		Ifindex: int32(c.ifIndex),
-		Type:    unix.PACKET_MR_PROMISC,
+		Type:    Type,
+		Alen:    ETH_ALEN,
+	}
+	if Type == unix.PACKET_MR_MULTICAST {
+		copy(mreq.Address[:], addr)
 	}
 
 	membership := unix.PACKET_DROP_MEMBERSHIP


### PR DESCRIPTION
I needed a way to receive ethernet multicast packets (LLDP to be specific), but not enable promiscuous mode.  This allows for that by exposing the call to SetsockoptPacketMreq not just for the unix.PACKET_MR_PROMISC but any.